### PR TITLE
Release/v1 14 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Miva IDE CHANGELOG
 
-## v1.13.0 (latest)
+## v1.14.0 (latest)
+
+* Modified the `mvt-debug` snippet to be different for `mvtjs`, `mvtcss` and `mvt` languages.
+	* `mvtcss` will output a CSS block comment.
+	* `mvtjs` will output a `console.log()` call with a JSON string.
+	* `mvt` will retain existing functionality.
+
+## v1.13.0
 
 * Added new `mvt-debug-textarea` snippet.
 	* Outputs a readonly textarea that resizes to fit content and decodes the debugged variable data.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,6 +88,13 @@ This is the existing development flow. When new LSK or Empressa versions are rel
 - [x] Fix syntax issue for Miva Script expressions.
 	- See "LSK/src/features/prv/mmlsk-prv_ad.mv" for an example.
 
+### v1.14.0
+
+- [x] Create language specific debug snippets.
+	- mvtcss will only allow a css comment wrap
+	- mvtjs will only allow a json encoded console.log wrap
+	- mvt standard will allow the existing 3 (debug, debug-json, debug-textarea)
+
 ### v1.X.0
 
 - [ ] Fix indentation issues when running Reindent Lines.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-miva-ide",
-	"version": "1.13.0",
+	"version": "1.14.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-miva-ide",
-			"version": "1.13.0",
+			"version": "1.14.0",
 			"workspaces": [
 				"client",
 				"server"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-miva-ide",
 	"displayName": "Miva IDE",
 	"description": "Syntax highlighting, snippets and tools for building websites with Miva.",
-	"version": "1.13.0",
+	"version": "1.14.0",
 	"engines": {
 		"vscode": "^1.77.0",
 		"node": ">=16"

--- a/server/src/miva-features.ts
+++ b/server/src/miva-features.ts
@@ -33,7 +33,7 @@ import systemVariableData from './mv/system-variables';
 import { mvSnippetData, mvTagData } from './mv/tags';
 import mvtEntityData from './mvt/entities';
 import mvtItemData from './mvt/items';
-import { generateMvtTags, mvtSnippetData } from './mvt/tags';
+import { generateMvtSnippets, generateMvtTags } from './mvt/tags';
 import {
 	filterTagData,
 	formatGenericDocumentation,
@@ -256,12 +256,13 @@ export function activateFeatures(workspaceSymbolProvider?: WorkspaceSymbolProvid
 			return symbols;
 		};
 
-		const buildTagCompletionData = (settings: Settings) => {
-			if (!settingsChanged) {
-				return;
+		const buildTagCompletionData = (settings: Settings, languageId: string) => {
+			mvtSnippetData = generateMvtSnippets(settings, languageId);
+
+			if (settingsChanged) {
+				mvtTagData = generateMvtTags(settings);
 			}
 
-			mvtTagData = generateMvtTags(settings);
 			mvtTagAndSnippetData = {
 				...mvtSnippetData,
 				...mvtTagData
@@ -286,6 +287,7 @@ export function activateFeatures(workspaceSymbolProvider?: WorkspaceSymbolProvid
 
 		// MVT-specific completion data
 		let mvtTagData: Record<string, TagData>;
+		let mvtSnippetData: Record<string, TagSnippet>;
 		let mvtTagAndSnippetData: Record<string, TagData | TagSnippet>;
 		let mvtTagCompletions: CompletionList;
 		const entityCompletions: CompletionList = CompletionList.create( parseCompletionFile( Object.values( mvtEntityData ) ) );
@@ -383,7 +385,7 @@ export function activateFeatures(workspaceSymbolProvider?: WorkspaceSymbolProvid
 
 			doCompletion( document: TextDocument, position: Position, settings: Settings ): CompletionList {
 
-				buildTagCompletionData( settings );
+				buildTagCompletionData( settings, document.languageId );
 
 				const {document: mvtDocument} = mvtDocuments.get( document );
 				const parsedDocument = htmlLanguageService.parseHTMLDocument(document);
@@ -604,7 +606,7 @@ export function activateFeatures(workspaceSymbolProvider?: WorkspaceSymbolProvid
 					return defaultReturnValue;
 				}
 
-				buildTagCompletionData( settings );
+				buildTagCompletionData( settings, document.languageId );
 
 				await _createMivaScriptWorkspaceSymbols(workspace, settings);
 

--- a/server/src/mvt/tags.ts
+++ b/server/src/mvt/tags.ts
@@ -84,47 +84,79 @@ const tagItem = {
 
 // Snippet data structure
 
-export const mvtSnippetData: Record<string, TagSnippet> = {
-	debug: {
-		...baseTag,
-		documentation: '',
-		kind: CompletionItemKind.Function,
-		insertText: "<mvt:assign name=\"l.settings:_mvt_debug\" value=\"glosub( miva_array_serialize( ${1:variable} ), ',', asciichar( 10 ) )\" />\r\n${2|<pre>,<!--|}\r\n@@debug $1\r\n&mvt:_mvt_debug;\r\n${3|</pre>,-->|}",
-		label: 'mvt-debug'
-	},
-	debug_json: {
-		...baseTag,
-		documentation: '',
-		kind: CompletionItemKind.Function,
-		insertText: "<mvt:assign name=\"l.settings:_mvt_debug\" value=\"miva_json_encode( ${1:variable}, 'pretty' )\" />\r\n${2|<pre>,<!--|}\r\n@@debug $1\r\n&mvt:_mvt_debug;\r\n${3|</pre>,-->|}",
-		label: 'mvt-debug-json'
-	},
-	debug_textarea: {
-		...baseTag,
-		documentation: '',
-		kind: CompletionItemKind.Function,
-		insertText: [
-			`<mvt:assign name="l.settings:_mvt_debug" value="glosub( miva_array_serialize( $\{1:variable\} ), ',', asciichar( 10 ) )" />`,
-			`<label for="_mvt_debug_$CURRENT_SECONDS_UNIX">@@debug $1</label>`,
-			`<textarea id="_mvt_debug_$CURRENT_SECONDS_UNIX" readonly>&mvt:_mvt_debug;</textarea>`,
-			`<script>(function () {var e = document.getElementById('_mvt_debug_$CURRENT_SECONDS_UNIX');e.value = decodeURIComponent(e.value);e.style = 'height:' + e.scrollHeight + 'px;overflow-y:hidden';})();</script>`
-		].join('\n'),
-		label: 'mvt-debug-textarea'
-	},
-	testuser: {
-		...baseTag,
-		documentation: '',
-		kind: CompletionItemKind.Function,
-		insertText: "<mvt:comment> Start Testing Conditional </mvt:comment>\n<mvt:if expr=\"g.customer:login EQ '${1:test}'\">\n\n\n\n\n${2}\n\n\n\n\n${3:<mvt:else>}\n${0}\n</mvt:if>\n<mvt:comment> / end Testing Conditional </mvt:comment>",
-		label: 'mvt-testuser'
-	},
-	testvar: {
-		...baseTag,
-		documentation: '',
-		kind: CompletionItemKind.Function,
-		insertText: "<mvt:comment> Start Testing Conditional </mvt:comment>\n<mvt:if expr=\"${1:g.test EQ 1}\">\n\n\n\n\n${2}\n\n\n\n\n${3:<mvt:else>}\n${0}\n</mvt:if>\n<mvt:comment> / end Testing Conditional </mvt:comment>",
-		label: 'mvt-testvar'
-	}
+export function generateMvtSnippets (settings: Settings, languageId: string): Record<string, TagSnippet> {
+	const getLanguageSpecificSnippets = (): Record<string, TagSnippet> => {
+		switch (languageId) {
+			case 'mvtcss':
+				return {
+					debug: {
+						...baseTag,
+						documentation: '',
+						kind: CompletionItemKind.Function,
+						insertText: "<mvt:assign name=\"l.settings:_mvt_debug\" value=\"glosub( miva_array_serialize( ${1:variable} ), ',', asciichar( 10 ) )\" />\r\n/*\r\n@@debug $1\r\n&mvt:_mvt_debug;\r\n*/",
+						label: 'mvt-debug'
+					}
+				}
+			case 'mvtjs':
+				return {
+					debug: {
+						...baseTag,
+						documentation: '',
+						kind: CompletionItemKind.Function,
+						insertText: "<mvt:assign name=\"l.settings:_mvt_debug\" value=\"miva_json_encode( ${1:variable}, 'pretty' )\" />\r\nconsole.log('@@debug $1', '&mvt:_mvt_debug;')",
+						label: 'mvt-debug'
+					}
+				}
+			case 'mvt':
+			default:
+				return {
+					debug: {
+						...baseTag,
+						documentation: '',
+						kind: CompletionItemKind.Function,
+						insertText: "<mvt:assign name=\"l.settings:_mvt_debug\" value=\"glosub( miva_array_serialize( ${1:variable} ), ',', asciichar( 10 ) )\" />\r\n${2|<pre>,<!--|}\r\n@@debug $1\r\n&mvt:_mvt_debug;\r\n${3|</pre>,-->|}",
+						label: 'mvt-debug'
+					},
+					debug_json: {
+						...baseTag,
+						documentation: '',
+						kind: CompletionItemKind.Function,
+						insertText: "<mvt:assign name=\"l.settings:_mvt_debug\" value=\"miva_json_encode( ${1:variable}, 'pretty' )\" />\r\n${2|<pre>,<!--|}\r\n@@debug $1\r\n&mvt:_mvt_debug;\r\n${3|</pre>,-->|}",
+						label: 'mvt-debug-json'
+					},
+					debug_textarea: {
+						...baseTag,
+						documentation: '',
+						kind: CompletionItemKind.Function,
+						insertText: [
+							`<mvt:assign name="l.settings:_mvt_debug" value="glosub( miva_array_serialize( $\{1:variable\} ), ',', asciichar( 10 ) )" />`,
+							`<label for="_mvt_debug_$CURRENT_SECONDS_UNIX">@@debug $1</label>`,
+							`<textarea id="_mvt_debug_$CURRENT_SECONDS_UNIX" readonly>&mvt:_mvt_debug;</textarea>`,
+							`<script>(function () {var e = document.getElementById('_mvt_debug_$CURRENT_SECONDS_UNIX');e.value = decodeURIComponent(e.value);e.style = 'height:' + e.scrollHeight + 'px;overflow-y:hidden';})();</script>`
+						].join('\n'),
+						label: 'mvt-debug-textarea'
+					}
+				};
+		}
+	};
+
+	return {
+		...getLanguageSpecificSnippets(),
+		testuser: {
+			...baseTag,
+			documentation: '',
+			kind: CompletionItemKind.Function,
+			insertText: "<mvt:comment> Start Testing Conditional </mvt:comment>\n<mvt:if expr=\"g.customer:login EQ '${1:test}'\">\n\n\n\n\n${2}\n\n\n\n\n${3:<mvt:else>}\n${0}\n</mvt:if>\n<mvt:comment> / end Testing Conditional </mvt:comment>",
+			label: 'mvt-testuser'
+		},
+		testvar: {
+			...baseTag,
+			documentation: '',
+			kind: CompletionItemKind.Function,
+			insertText: "<mvt:comment> Start Testing Conditional </mvt:comment>\n<mvt:if expr=\"${1:g.test EQ 1}\">\n\n\n\n\n${2}\n\n\n\n\n${3:<mvt:else>}\n${0}\n</mvt:if>\n<mvt:comment> / end Testing Conditional </mvt:comment>",
+			label: 'mvt-testvar'
+		}
+	};
 };
 
 // Full tag data structure


### PR DESCRIPTION
* Modified the `mvt-debug` snippet to be different for `mvtjs`, `mvtcss` and `mvt` languages.
	* `mvtcss` will output a CSS block comment.
	* `mvtjs` will output a `console.log()` call with a JSON string.
	* `mvt` will retain existing functionality.